### PR TITLE
Preserve power state polling preference

### DIFF
--- a/drivers/Samsung/device.ts
+++ b/drivers/Samsung/device.ts
@@ -41,6 +41,15 @@ module.exports = class SamsungDevice extends BaseDevice {
         }
     }
 
+    async setPowerState(powerState: boolean): Promise<void> {
+        try {
+            await this.setCapabilityValue('onoff', powerState).catch((err: any) => this.logger.error(err));
+            this.logger.info('setPowerState', powerState);
+        } catch (err) {
+            this.logger.info('setPowerState ERROR', err);
+        }
+    }
+
     async onSettings({
         oldSettings,
         newSettings,

--- a/tasks/community-posts/power-state-polling-setting-disables-itself.md
+++ b/tasks/community-posts/power-state-polling-setting-disables-itself.md
@@ -1,6 +1,6 @@
 # Power state polling setting appears to disable itself
 
-Status: Candidate small bug
+Status: Fix implemented — [GitHub issue #54](https://github.com/balmli/com.samsung.smart/issues/54)
 
 Area: Shared device setting used by the maintained `Samsung` driver
 
@@ -18,6 +18,16 @@ A user reports that the “Power state polling” setting becomes disabled autom
 - The `set_power_state` Flow action calls this method.
 - A one-off Flow action therefore appears able to persistently change an advanced device setting as a side effect.
 
+## Confirmation evidence
+
+The defect is certain from deterministic code behavior: the registered `set_power_state` Flow action calls
+`BaseDevice.setPowerState()`, which unconditionally persists `power_state_polling = false` before updating the
+`onoff` capability. No TV or network behavior is involved in that setting mutation.
+
+Polling should not be paused by the manual action. When polling remains enabled, the existing bounded polling loop
+will reconcile the manually supplied state with the detected TV state on the next configured interval. This avoids
+an immediate extra poll while preserving the user's preference.
+
 ## Expected behavior
 
 Using “Set power state” should update Homey's current state without silently changing the user's polling preference.
@@ -32,3 +42,15 @@ Using “Set power state” should update Homey's current state without silently
 ## Hardware verification
 
 Primarily testable with Homey device mocks; perform a short real-device check to verify the next poll behaves sensibly.
+
+## Implementation and verification
+
+- The maintained `Samsung` driver overrides `setPowerState()` so the action updates `onoff` without changing the
+  polling preference. Shared `BaseDevice` behavior remains unchanged for the retained encrypted and legacy drivers.
+- Regression test red: `npm test --ignore-scripts -- --grep SamsungDevice.setPowerState` failed because the setting
+  changed from `true` to `false`.
+- Regression test green: the same focused command passed after the maintained-driver override.
+- Node 24.16.0 checks passed: `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (41 passing).
+- No manifest or generated `app.json` changes were required.
+- Real-TV behavior remains unverified; the next scheduled poll should be checked on maintained Samsung hardware.

--- a/tasks/community-posts/power-state-polling-setting-disables-itself.md
+++ b/tasks/community-posts/power-state-polling-setting-disables-itself.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #54](https://github.com/balmli/com.samsung.smart/issues/54)
 
+Pull request: [#55](https://github.com/balmli/com.samsung.smart/pull/55)
+
 Area: Shared device setting used by the maintained `Samsung` driver
 
 ## Problem

--- a/test/test_set_power_state.ts
+++ b/test/test_set_power_state.ts
@@ -1,0 +1,41 @@
+const expect = require("chai").expect;
+
+const Module = require("module");
+const originalLoad = Module._load;
+Module._load = function () {
+    const [request] = arguments;
+    if (request === "homey") {
+        return {Device: class {}};
+    }
+    return originalLoad.apply(this, arguments);
+};
+const SamsungDevice = require("../drivers/Samsung/device");
+Module._load = originalLoad;
+const {DeviceSettings} = require("../lib/types");
+
+describe("SamsungDevice.setPowerState", function () {
+    it("preserves the power-state polling preference", async function () {
+        const settings = new Map([[DeviceSettings.power_state_polling, true]]);
+        const capabilities = new Map();
+        const device = Object.create(SamsungDevice.prototype);
+        device.config = {
+            setSetting: async function () {
+                const [key, value] = arguments;
+                settings.set(key, value);
+            },
+        };
+        device.setCapabilityValue = async function () {
+            const [capability, value] = arguments;
+            capabilities.set(capability, value);
+        };
+        device.logger = {
+            error: () => undefined,
+            info: () => undefined,
+        };
+
+        await device.setPowerState(false);
+
+        expect(capabilities.get("onoff")).to.equal(false);
+        expect(settings.get(DeviceSettings.power_state_polling)).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Summary

- preserve the configured power-state polling preference when the maintained Samsung driver handles **Set power state**
- let the existing scheduled poll reconcile the manual state on the next configured interval
- keep shared `BaseDevice` behavior unchanged so retained encrypted and legacy drivers are not modified

Task source: `tasks/community-posts/power-state-polling-setting-disables-itself.md`
Community report: https://community.homey.app/t/app-pro-samsung-smarttv/10019/625

Fixes #54

## Evidence and TDD

The defect is deterministic: shared `BaseDevice.setPowerState()` persists `power_state_polling = false` before setting `onoff`. The maintained driver inherited that behavior.

Red: `npm test --ignore-scripts -- --grep SamsungDevice.setPowerState` failed with `expected false to equal true`.

Green: the same focused command passed after adding the maintained-driver override.

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 41 passing

No manifest or generated `app.json` changes were required.

## Compatibility and hardware

Only `drivers/Samsung/` production behavior changes. The encrypted and legacy drivers retain their existing shared behavior and were not hardware-tested. The persistent setting mutation is covered by a Homey-style unit mock; real maintained Samsung TV verification of the next scheduled poll remains outstanding.