### PR TITLE
Keep power-state polling alive during online refresh

### DIFF
--- a/drivers/Samsung/device.ts
+++ b/drivers/Samsung/device.ts
@@ -6,6 +6,7 @@ import {SamsungClientImpl} from './SamsungClient';
 module.exports = class SamsungDevice extends BaseDevice {
     pairRetries: number = 3;
     lastAppsRefreshTs: number = 0;
+    private onlineRefreshPromise?: Promise<void>;
 
     async onInit(): Promise<void> {
         await super.initDevice('Samsung');
@@ -92,6 +93,21 @@ module.exports = class SamsungDevice extends BaseDevice {
     }
 
     async onDeviceOnline() {
+        if (this.onlineRefreshPromise) {
+            return;
+        }
+
+        const refreshPromise = this.refreshOnlineState()
+            .catch(err => this.logger.info('onDeviceOnline ERROR', err))
+            .finally(() => {
+                if (this.onlineRefreshPromise === refreshPromise) {
+                    this.onlineRefreshPromise = undefined;
+                }
+            });
+        this.onlineRefreshPromise = refreshPromise;
+    }
+
+    private async refreshOnlineState() {
         await this.shouldFetchPowerState();
         await this.shouldFetchModelName();
         await this.pairDevice();

--- a/tasks/community-posts/power-state-polling-stalls.md
+++ b/tasks/community-posts/power-state-polling-stalls.md
@@ -1,6 +1,6 @@
 # Power state polling becomes stale until the app or Homey restarts
 
-Status: Candidate bug
+Status: Fix implemented — [GitHub issue #56](https://github.com/balmli/com.samsung.smart/issues/56)
 
 Area: Maintained `Samsung` driver and shared polling lifecycle
 
@@ -21,6 +21,20 @@ Multiple users report that Homey eventually stops reflecting whether a TV is on 
 - `isDeviceOnline()` combines several asynchronous probes and can return `undefined`.
 - A rejected probe, stale transition flag, timer lifecycle error, or socket state may prevent later useful status updates.
 
+## Confirmation evidence
+
+The recursive timeout is scheduled in `BaseDevice.doPowerStatePolling()` only after the complete online refresh
+settles. For an online TV, the maintained driver awaits pairing, application discovery, and UPnP state refresh.
+Samsung WebSocket connection and pairing promises contain paths that can remain pending indefinitely. A pending
+online refresh therefore prevents the polling `finally` block from scheduling the next timeout.
+
+Restarting the app schedules a fresh one-second poll, matching the reported temporary recovery. Historical code used
+`setInterval`, so an individual pending online refresh did not own creation of the next timer.
+
+The polling interval is not the defect: the documented contract says values below 10 seconds disable polling.
+Rejected probes, `undefined` results, and active transition skips currently reach `finally` and reschedule; focused
+tests should preserve those behaviors.
+
 ## Expected behavior
 
 Polling continues for the lifetime of the device and eventually reconciles Homey's `onoff` capability with the TV without requiring an app or Homey restart.
@@ -36,3 +50,19 @@ Polling continues for the lifetime of the device and eventually reconciles Homey
 ## Hardware verification
 
 Requires long-running validation on at least one modern Samsung TV. Compilation and mocked timers cannot establish that the Samsung endpoints remain reachable over time.
+
+## Implementation and verification
+
+- The maintained `Samsung` driver now starts online-device maintenance in the background, allowing the shared polling
+  callback to finish and schedule its next timeout even if maintenance remains pending.
+- A single-flight guard prevents overlapping maintenance work and clears after completion or rejection so a later
+  poll can refresh again.
+- Regression test red: the next poll was not scheduled while maintenance was pending, and two callbacks started two
+  concurrent maintenance refreshes.
+- Regression test green: all six focused lifecycle cases pass, including rejected and indeterminate probes,
+  transition skips, non-overlap, guard release, and later status recovery.
+- Node 24.16.0 checks passed: `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (47 passing).
+- Only `drivers/Samsung/` production behavior changed. No manifest or generated `app.json` changes were required.
+- Long-running modern-TV verification remains outstanding. Encrypted and legacy driver behavior was not changed or
+  hardware-tested.

--- a/tasks/community-posts/power-state-polling-stalls.md
+++ b/tasks/community-posts/power-state-polling-stalls.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #56](https://github.com/balmli/com.samsung.smart/issues/56)
 
+Pull request: [#57](https://github.com/balmli/com.samsung.smart/pull/57)
+
 Area: Maintained `Samsung` driver and shared polling lifecycle
 
 ## Problem

--- a/test/test_set_power_state.ts
+++ b/test/test_set_power_state.ts
@@ -39,3 +39,140 @@ describe("SamsungDevice.setPowerState", function () {
         expect(settings.get(DeviceSettings.power_state_polling)).to.equal(true);
     });
 });
+
+function createPollingDevice() {
+    const state = {
+        available: true,
+        onOff: false,
+        scheduledPolls: 0,
+    };
+    const device = Object.create(SamsungDevice.prototype);
+    device.logger = {
+        error: () => undefined,
+        info: () => undefined,
+        verbose: () => undefined,
+    };
+    device.getSetting = function () {
+        const [key] = arguments;
+        return key === DeviceSettings.power_state_polling ? true : undefined;
+    };
+    device.getCapabilityValue = () => state.onOff;
+    device.setCapabilityValue = async function () {
+        const [capability, value] = arguments;
+        if (capability === "onoff") {
+            state.onOff = value;
+        }
+    };
+    device.getAvailable = () => state.available;
+    device.setAvailable = async () => {
+        state.available = true;
+    };
+    device.schedulePowerStatePolling = () => {
+        state.scheduledPolls++;
+    };
+    device.shouldFetchPowerState = async () => undefined;
+    device.shouldFetchModelName = async () => undefined;
+    device.pairDevice = async () => undefined;
+    device.shouldRefreshAppList = async () => undefined;
+    device.fetchState = async () => undefined;
+    return {device, state};
+}
+
+describe("SamsungDevice power-state polling", function () {
+    it("reschedules while online maintenance remains pending", async function () {
+        const {device, state} = createPollingDevice();
+        let finishRefresh = () => {};
+        const pendingRefresh = new Promise(resolve => {
+            finishRefresh = () => resolve(undefined);
+        });
+        device.isDeviceOnline = async () => true;
+        device.shouldFetchPowerState = () => pendingRefresh;
+
+        const poll = device.doPowerStatePolling();
+        await new Promise(resolve => setImmediate(resolve));
+        const scheduledWhilePending = state.scheduledPolls;
+        finishRefresh();
+        await poll;
+
+        expect(scheduledWhilePending).to.equal(1);
+    });
+
+    it("does not overlap online maintenance", async function () {
+        const {device} = createPollingDevice();
+        let refreshes = 0;
+        let finishRefresh = () => {};
+        const pendingRefresh = new Promise(resolve => {
+            finishRefresh = () => resolve(undefined);
+        });
+        device.shouldFetchPowerState = () => {
+            refreshes++;
+            return pendingRefresh;
+        };
+
+        const firstRefresh = device.onDeviceOnline();
+        const secondRefresh = device.onDeviceOnline();
+        await new Promise(resolve => setImmediate(resolve));
+        const refreshesWhilePending = refreshes;
+        finishRefresh();
+        await Promise.all([firstRefresh, secondRefresh]);
+
+        expect(refreshesWhilePending).to.equal(1);
+    });
+
+    it("allows online maintenance to run again after completion", async function () {
+        const {device} = createPollingDevice();
+        let refreshes = 0;
+        device.shouldFetchPowerState = async () => {
+            refreshes++;
+        };
+
+        await device.onDeviceOnline();
+        await device.onlineRefreshPromise;
+        await device.onDeviceOnline();
+        await device.onlineRefreshPromise;
+
+        expect(refreshes).to.equal(2);
+    });
+
+    it("reschedules after a rejected probe without changing state", async function () {
+        const {device, state} = createPollingDevice();
+        device.isDeviceOnline = async () => {
+            throw new Error("temporary probe failure");
+        };
+        device.onDeviceOnline = async () => undefined;
+
+        await device.doPowerStatePolling();
+
+        expect(state.onOff).to.equal(false);
+        expect(state.scheduledPolls).to.equal(1);
+    });
+
+    it("reschedules while a power transition is active", async function () {
+        const {device, state} = createPollingDevice();
+        let probes = 0;
+        device.turning_onoff_process = true;
+        device.isDeviceOnline = async () => {
+            probes++;
+            return true;
+        };
+
+        await device.doPowerStatePolling();
+
+        expect(probes).to.equal(0);
+        expect(state.scheduledPolls).to.equal(1);
+    });
+
+    it("recovers after an indeterminate probe", async function () {
+        const {device, state} = createPollingDevice();
+        const probeResults = [undefined, true];
+        device.isDeviceOnline = async () => probeResults.shift();
+        device.onDeviceOnline = async () => undefined;
+
+        await device.doPowerStatePolling();
+        expect(state.onOff).to.equal(false);
+
+        await device.doPowerStatePolling();
+        expect(state.onOff).to.equal(true);
+        expect(state.scheduledPolls).to.equal(2);
+    });
+});


### PR DESCRIPTION
## Summary

- decouple maintained-driver online maintenance from the recursive power-state timer chain
- allow the polling callback to schedule its next timeout even when WebSocket-backed maintenance remains pending
- prevent overlapping maintenance work with a single-flight guard that clears after completion or rejection
- preserve current behavior for rejected and indeterminate probes, active transitions, and later status recovery

Task source: `tasks/community-posts/power-state-polling-stalls.md`
Community reports: https://community.homey.app/t/app-pro-samsung-smarttv/10019/502 and https://community.homey.app/t/app-pro-samsung-smarttv/10019/557

Fixes #56

## Evidence and root cause

`BaseDevice.doPowerStatePolling()` creates its next recursive timeout only in `finally`, after awaiting `onDeviceOnline()`. The maintained driver previously awaited pairing, app discovery, and UPnP refresh there. Samsung WebSocket connection and pairing promises contain paths that can remain pending indefinitely, so one stuck maintenance operation could prevent the next status timeout from ever being created. Restarting the app creates a new initial poll, matching the reports.

The polling interval is not the defect: the documented contract says values below 10 seconds disable polling. Tests confirm that thrown probes, `undefined` results, and transition skips already reschedule.

## TDD

Red:

- next poll count remained zero while online maintenance was pending
- two callbacks started two concurrent maintenance refreshes

Green:

- next poll is scheduled while maintenance remains pending
- only one maintenance refresh runs at a time
- the guard clears after completion
- rejected and indeterminate probes do not emit an incorrect state
- transition skips reschedule
- a later reachable probe updates `onoff`

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 47 passing

No manifest or generated `app.json` changes were required.

## Compatibility and hardware

Only `drivers/Samsung/` production behavior changes. Shared `BaseDevice`, encrypted, and legacy driver behavior remains unchanged. Long-running verification on a modern Samsung TV remains outstanding; no retained driver was hardware-tested.