### PR TITLE
Recover power transitions from failures and timeouts

### DIFF
--- a/drivers/Samsung/device.ts
+++ b/drivers/Samsung/device.ts
@@ -7,8 +7,12 @@ module.exports = class SamsungDevice extends BaseDevice {
     pairRetries: number = 3;
     lastAppsRefreshTs: number = 0;
     private onlineRefreshPromise?: Promise<void>;
+    private powerTransitionResolve?: () => void;
+    private powerTransitionReject?: (error: Error) => void;
 
     async onInit(): Promise<void> {
+        this.deleted = false;
+        this.finishPowerTransition();
         await super.initDevice('Samsung');
 
         await this.initSettings();
@@ -48,6 +52,95 @@ module.exports = class SamsungDevice extends BaseDevice {
             this.logger.info('setPowerState', powerState);
         } catch (err) {
             this.logger.info('setPowerState ERROR', err);
+        }
+    }
+
+    async turnOnOff(onOff: boolean): Promise<void> {
+        if (this.turning_onoff_process !== undefined) {
+            throw new Error(
+                this.homey.__(
+                    this.turning_onoff_process ? 'errors.onoff.on_in_progress' : 'errors.onoff.off_in_progress',
+                ),
+            );
+        }
+
+        const transition = new Promise<void>((resolve, reject) => {
+            this.powerTransitionResolve = resolve;
+            this.powerTransitionReject = reject;
+        });
+        transition.catch(() => undefined);
+
+        try {
+            this.turning_onoff_process = onOff;
+            this.scheduleOnOffPolling();
+            this.scheduleOnOffTimeout();
+
+            if (onOff) {
+                this.wakeRetries = 5;
+            }
+            const command = onOff ? this.samsungClient.wake() : this.samsungClient.turnOff();
+            this.logger.info('turnOnOff: in progress: ' + (onOff ? 'on' : 'off'));
+            await Promise.race([command.then(() => transition), transition]);
+        } catch (err) {
+            this.finishPowerTransition();
+            this.logger.info('turnOnOff: failed: ', err);
+            throw err;
+        }
+    }
+
+    async doOnOffPollDevice() {
+        if (this.deleted || this.turning_onoff_process === undefined) {
+            return;
+        }
+
+        try {
+            const onOff = await this.isDeviceOnline(500);
+            if (this.turning_onoff_process === onOff) {
+                this.logger.info('doOnOffPollDevice: finished');
+                this.finishPowerTransition();
+                return;
+            }
+            if (this.turning_onoff_process && !onOff && this.wakeRetries > 0) {
+                this.wakeRetries--;
+                await this.samsungClient.wake();
+            }
+        } catch (err) {
+            this.logger.info(err);
+        } finally {
+            if (!this.deleted && this.turning_onoff_process !== undefined) {
+                this.scheduleOnOffPolling();
+            }
+        }
+    }
+
+    onOnOffTimeout() {
+        if (this.turning_onoff_process === undefined) {
+            this.clearOnOffTimeout();
+            return;
+        }
+
+        this.finishPowerTransition(new Error(this.homey.__('errors.connection_timeout')));
+    }
+
+    onDeleted() {
+        this.finishPowerTransition();
+        super.onDeleted();
+    }
+
+    private finishPowerTransition(error?: Error) {
+        const resolve = this.powerTransitionResolve;
+        const reject = this.powerTransitionReject;
+        this.powerTransitionResolve = undefined;
+        this.powerTransitionReject = undefined;
+        this.turning_onoff_process = undefined;
+        this.wakeRetries = 0;
+        this.clearOnOffPolling();
+        this.clearOnOffTimeout();
+
+        if (error) {
+            reject?.(error);
+        } else {
+            resolve?.();
         }
     }
 

--- a/lib/BaseDevice.ts
+++ b/lib/BaseDevice.ts
@@ -23,8 +23,8 @@ export class BaseDevice extends Homey.Device {
     onOffPollingTimeout?: NodeJS.Timeout;
     onOffCheckTimeout?: NodeJS.Timeout;
     powerStatePollingTimeout?: NodeJS.Timeout;
-    private wakeRetries: number = 0;
-    private deleted?: boolean;
+    protected wakeRetries: number = 0;
+    protected deleted?: boolean;
 
     async initDevice(deviceType: string) {
         // @ts-ignore

--- a/tasks/community-posts/power-transition-stuck-in-progress.md
+++ b/tasks/community-posts/power-transition-stuck-in-progress.md
@@ -1,6 +1,6 @@
 # Power transition remains stuck in “in progress”
 
-Status: Candidate bug
+Status: Fix implemented — [GitHub issue #58](https://github.com/balmli/com.samsung.smart/issues/58)
 
 Area: Maintained `Samsung` driver and shared transition state
 
@@ -21,6 +21,16 @@ Users report persistent “power on/off in progress” errors followed by an unr
 - The flag is cleared by successful state reconciliation or the 30-second timeout callback.
 - Timer cancellation, deletion/reinitialization, or an exception in the polling chain could leave the flag set or prevent timeout recovery.
 
+## Confirmation evidence
+
+The command-failure path is deterministically broken. `BaseDevice.turnOnOff()` sets `turning_onoff_process`, then
+awaits `wake()` or `turnOff()`. If the command rejects, the catch block cancels both recovery timers but does not clear
+the transition flag. With no timer left to recover it, every later power command is rejected as already in progress.
+
+Successful transition polling also clears its timers and then unconditionally schedules another poll from `finally`.
+The timeout callback clears polling and transition state but retains its own stored timeout handle. Initialization and
+deletion do not explicitly reset a stale transition flag.
+
 ## Expected behavior
 
 A transition must always resolve successfully or time out into a recoverable state. A later power command should never require rebooting Homey.
@@ -35,3 +45,22 @@ A transition must always resolve successfully or time out into a recoverable sta
 ## Hardware verification
 
 Simulate an unreachable TV, then restore connectivity and verify subsequent power commands on a modern Samsung TV.
+
+## Implementation and verification
+
+- The maintained `Samsung` driver now waits for a transition outcome and uses one cleanup path for success, command
+  failure, timeout, initialization, and deletion.
+- Transition polling is rescheduled only while a transition remains active. A transient poll or Wake-on-LAN retry
+  failure therefore continues toward the existing 30-second timeout without leaving an extra terminal timer.
+- Timeout rejects the waiting command with the existing localized connection-timeout error, clears both timers and
+  retry state, and permits a subsequent command.
+- Regression test red: six focused lifecycle cases failed for retained flags, stray timers, missing timeout errors,
+  and missing initialization/deletion cleanup.
+- Regression test green: all seven focused transition cases pass, including duplicate-command blocking only during
+  an active transition.
+- Node 24.16.0 checks passed: `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (54 passing).
+- Only `drivers/Samsung/` runtime behavior changed. Two shared fields changed from `private` to `protected` for the
+  maintained override; encrypted and legacy runtime behavior is unchanged.
+- No manifest or generated `app.json` changes were required. Modern-TV failure/recovery testing remains outstanding;
+  encrypted and legacy drivers were not hardware-tested.

--- a/tasks/community-posts/power-transition-stuck-in-progress.md
+++ b/tasks/community-posts/power-transition-stuck-in-progress.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #58](https://github.com/balmli/com.samsung.smart/issues/58)
 
+Pull request: [#59](https://github.com/balmli/com.samsung.smart/pull/59)
+
 Area: Maintained `Samsung` driver and shared transition state
 
 ## Problem

--- a/test/test_set_power_state.ts
+++ b/test/test_set_power_state.ts
@@ -12,6 +12,7 @@ Module._load = function () {
 const SamsungDevice = require("../drivers/Samsung/device");
 Module._load = originalLoad;
 const {DeviceSettings} = require("../lib/types");
+const BaseDevice = Object.getPrototypeOf(SamsungDevice.prototype).constructor;
 
 describe("SamsungDevice.setPowerState", function () {
     it("preserves the power-state polling preference", async function () {
@@ -174,5 +175,188 @@ describe("SamsungDevice power-state polling", function () {
         await device.doPowerStatePolling();
         expect(state.onOff).to.equal(true);
         expect(state.scheduledPolls).to.equal(2);
+    });
+});
+
+function createTransitionDevice() {
+    let timerId = 0;
+    const timers = new Map();
+    const device = Object.create(SamsungDevice.prototype);
+    device.homey = {
+        __: function () {
+            return arguments[0];
+        },
+        setTimeout: function () {
+            const [callback, delay] = arguments;
+            const timer = {callback, delay, id: ++timerId};
+            timers.set(timer.id, timer);
+            return timer;
+        },
+        clearTimeout: function () {
+            const [timer] = arguments;
+            timers.delete(timer.id);
+        },
+    };
+    device.logger = {
+        error: () => undefined,
+        info: () => undefined,
+        verbose: () => undefined,
+    };
+    device.samsungClient = {
+        wake: async () => undefined,
+        turnOff: async () => undefined,
+    };
+    device.clearPowerStatePolling = () => undefined;
+    return {device, timers};
+}
+
+describe("SamsungDevice power transitions", function () {
+    it("cleans up after a rejected power command", async function () {
+        const {device} = createTransitionDevice();
+        device.samsungClient.wake = async () => {
+            throw new Error("wake failed");
+        };
+        let commandErrorMessage;
+
+        try {
+            await device.turnOnOff(true);
+        } catch (err) {
+            commandErrorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(commandErrorMessage).to.equal("wake failed");
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+    });
+
+    it("cleans up after a successful transition", async function () {
+        const {device} = createTransitionDevice();
+        device.isDeviceOnline = async () => true;
+
+        const command = device.turnOnOff(true);
+        await new Promise(resolve => setImmediate(resolve));
+        await device.doOnOffPollDevice();
+        await command;
+
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+    });
+
+    it("retries after a failed poll and then completes", async function () {
+        const {device} = createTransitionDevice();
+        const pollResults = [new Error("temporary poll failure"), true];
+        device.isDeviceOnline = async () => {
+            const result = pollResults.shift();
+            if (result instanceof Error) {
+                throw result;
+            }
+            return result;
+        };
+
+        const command = device.turnOnOff(true);
+        await new Promise(resolve => setImmediate(resolve));
+        await device.doOnOffPollDevice();
+        expect(device.turning_onoff_process).to.equal(true);
+        expect(device.onOffPollingTimeout).to.not.equal(undefined);
+
+        await device.doOnOffPollDevice();
+        await command;
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+    });
+
+    it("returns a timeout error and allows a later command", async function () {
+        const {device} = createTransitionDevice();
+        let commandErrorMessage;
+        const command = device.turnOnOff(true).catch(function () {
+            const [err] = arguments;
+            commandErrorMessage = err instanceof Error ? err.message : String(err);
+        });
+        await new Promise(resolve => setImmediate(resolve));
+
+        device.onOnOffTimeout();
+        await command;
+
+        expect(commandErrorMessage).to.equal("errors.connection_timeout");
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+
+        device.samsungClient.wake = async () => {
+            throw new Error("next command reached TV");
+        };
+        let nextCommandErrorMessage;
+        try {
+            await device.turnOnOff(true);
+        } catch (err) {
+            nextCommandErrorMessage = err instanceof Error ? err.message : String(err);
+        }
+        expect(nextCommandErrorMessage).to.equal("next command reached TV");
+    });
+
+    it("blocks duplicate commands only while a transition is active", async function () {
+        const {device} = createTransitionDevice();
+        device.isDeviceOnline = async () => true;
+
+        const command = device.turnOnOff(true);
+        await new Promise(resolve => setImmediate(resolve));
+        let duplicateErrorMessage;
+        try {
+            await device.turnOnOff(false);
+        } catch (err) {
+            duplicateErrorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(duplicateErrorMessage).to.equal("errors.onoff.on_in_progress");
+        await device.doOnOffPollDevice();
+        await command;
+    });
+
+    it("clears stale transition state during initialization", async function () {
+        const {device} = createTransitionDevice();
+        const originalInitDevice = BaseDevice.prototype.initDevice;
+        device.deleted = true;
+        device.turning_onoff_process = true;
+        device.scheduleOnOffPolling();
+        device.scheduleOnOffTimeout();
+        BaseDevice.prototype.initDevice = async () => undefined;
+        device.initSettings = async () => undefined;
+        device.migrate = async () => undefined;
+        device.registerCapListeners = async () => undefined;
+        device.schedulePowerStatePolling = () => undefined;
+        device.initSmartThings = async () => undefined;
+        device.config = {
+            getSetting: () => undefined,
+        };
+        device.homeyIpUtil = {};
+        device.getData = () => ({id: "test-tv"});
+
+        try {
+            await device.onInit();
+        } finally {
+            BaseDevice.prototype.initDevice = originalInitDevice;
+        }
+
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.deleted).to.equal(false);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+    });
+
+    it("clears transition state when the device is deleted", function () {
+        const {device} = createTransitionDevice();
+        device.turning_onoff_process = false;
+        device.scheduleOnOffPolling();
+        device.scheduleOnOffTimeout();
+
+        device.onDeleted();
+
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.deleted).to.equal(true);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
     });
 });


### PR DESCRIPTION
## Summary

- give the maintained Samsung driver one terminal cleanup path for power-transition success, command failure, timeout, initialization, and deletion
- wait for the detected transition outcome so the existing 30-second timeout is returned to the caller
- retry transient polling and Wake-on-LAN failures only while the transition remains active
- clear both transition timers and retry state on every terminal path
- keep duplicate-command blocking limited to a genuinely active transition

Task source: `tasks/community-posts/power-transition-stuck-in-progress.md`
Community reports: https://community.homey.app/t/app-pro-samsung-smarttv/10019/507 and https://community.homey.app/t/app-pro-samsung-smarttv/10019/653

Fixes #58

## Evidence and root cause

`BaseDevice.turnOnOff()` sets `turning_onoff_process` before awaiting `wake()` or `turnOff()`. Its command-failure catch cancels both recovery timers but does not clear the flag. No remaining callback can recover it, so every later command deterministically fails as already in progress.

Related terminal paths retained a stray poll timer after success, kept a stale timeout handle, or did not explicitly reset state during initialization/deletion.

## TDD

Red: six focused cases failed for the retained flag, stray timers, absent timeout rejection, and initialization/deletion cleanup. The duplicate-command invariant already passed.

Green: seven focused cases now pass:

- rejected command cleanup
- successful completion cleanup
- retry after transient poll failure
- timeout rejection and subsequent-command recovery
- duplicate blocking during an active transition
- initialization cleanup
- deletion cleanup

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 54 passing

No manifest or generated `app.json` changes were required.

## Compatibility and hardware

Only `drivers/Samsung/` runtime behavior changes. In `BaseDevice`, `wakeRetries` and `deleted` only change TypeScript visibility from private to protected for the maintained override. Encrypted and legacy runtime behavior remains unchanged and was not hardware-tested.

Modern Samsung hardware still needs an unreachable-TV test followed by restored connectivity and another power command.