### PR TITLE
Make Samsung power-off idempotent

### DIFF
--- a/drivers/Samsung/device.ts
+++ b/drivers/Samsung/device.ts
@@ -64,6 +64,11 @@ module.exports = class SamsungDevice extends BaseDevice {
             );
         }
 
+        if (!onOff && !this.getSetting(DeviceSettings.frameTVSupport) && this.getCapabilityValue('onoff') === false) {
+            this.logger.info('turnOnOff: TV is already off');
+            return;
+        }
+
         const transition = new Promise<void>((resolve, reject) => {
             this.powerTransitionResolve = resolve;
             this.powerTransitionReject = reject;

--- a/tasks/community-posts/power-off-command-turns-off-tv-on.md
+++ b/tasks/community-posts/power-off-command-turns-off-tv-on.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #60](https://github.com/balmli/com.samsung.smart/issues/60)
 
+Pull request: [#61](https://github.com/balmli/com.samsung.smart/pull/61)
+
 Area: Maintained `Samsung` driver
 
 ## Problem

--- a/tasks/community-posts/power-off-command-turns-off-tv-on.md
+++ b/tasks/community-posts/power-off-command-turns-off-tv-on.md
@@ -1,6 +1,6 @@
 # Sending “off” to an already-off TV can turn it on
 
-Status: Candidate bug
+Status: Fix implemented — [GitHub issue #60](https://github.com/balmli/com.samsung.smart/issues/60)
 
 Area: Maintained `Samsung` driver
 
@@ -20,6 +20,15 @@ A Homey “turn everything off” flow can turn on a Samsung TV that is already 
 - The capability listener starts the off operation without first proving the TV is currently on.
 - Frame TVs use a long power-key hold and have separate standby/art-mode semantics.
 
+## Confirmation evidence
+
+The defect is certain from deterministic command dispatch. `SamsungDevice.turnOnOff(false)` unconditionally calls
+the maintained client's `turnOff()` method. For a non-Frame TV, `SamsungClientImpl.turnOff()` sends the toggle-style
+`KEY_POWER`, even when Homey's current `onoff` capability reliably reports `false`. The redundant absolute-off
+request can therefore reverse the physical state instead of remaining off.
+
+Hardware is still required to establish model-specific behavior and to verify the separate Frame path.
+
 ## Expected behavior
 
 An absolute off request must be idempotent: requesting off while already off must not wake the TV.
@@ -34,3 +43,18 @@ An absolute off request must be idempotent: requesting off while already off mus
 ## Hardware verification
 
 Test repeated off commands against both an ordinary modern Samsung TV and, if available, a Frame TV. The Frame path remains unverified without hardware.
+
+## Implementation and verification
+
+- The maintained `Samsung` driver now treats an off request as complete without starting transition timers or sending
+  a power command when a non-Frame TV's current `onoff` capability is explicitly `false`.
+- Known-on and unknown states retain the existing off-command path. Frame TVs retain their separate long-hold path;
+  its hardware behavior remains unverified.
+- Regression test red: the focused known-off test failed because `samsungClient.turnOff()` was reached and raised
+  `redundant power-off command was sent`.
+- Regression test green: all 11 focused maintained-driver transition cases passed after the guard, including
+  known-on, unknown-state, and Frame-path preservation cases.
+- Node 24.16.0 checks passed: `npm run format`, `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (58 passing).
+- No shared, retained-driver, manifest, locale, or generated `app.json` changes were required. Real-TV verification
+  remains outstanding for both an ordinary modern Samsung TV and a Frame TV.

--- a/test/test_set_power_state.ts
+++ b/test/test_set_power_state.ts
@@ -206,11 +206,81 @@ function createTransitionDevice() {
         wake: async () => undefined,
         turnOff: async () => undefined,
     };
+    device.getSetting = () => undefined;
     device.clearPowerStatePolling = () => undefined;
     return {device, timers};
 }
 
 describe("SamsungDevice power transitions", function () {
+    it("does not send a power command when the TV is already known to be off", async function () {
+        const {device} = createTransitionDevice();
+        device.getCapabilityValue = () => false;
+        device.samsungClient.turnOff = async () => {
+            throw new Error("redundant power-off command was sent");
+        };
+
+        await device.turnOnOff(false);
+
+        expect(device.turning_onoff_process).to.equal(undefined);
+        expect(device.onOffPollingTimeout).to.equal(undefined);
+        expect(device.onOffCheckTimeout).to.equal(undefined);
+    });
+
+    it("sends the off command when the TV is known to be on", async function () {
+        const {device} = createTransitionDevice();
+        let offCommands = 0;
+        device.getCapabilityValue = () => true;
+        device.samsungClient.turnOff = async () => {
+            offCommands++;
+        };
+        device.isDeviceOnline = async () => false;
+
+        const command = device.turnOnOff(false);
+        await new Promise(resolve => setImmediate(resolve));
+        await device.doOnOffPollDevice();
+        await command;
+
+        expect(offCommands).to.equal(1);
+    });
+
+    it("preserves the off command when the current state is unknown", async function () {
+        const {device} = createTransitionDevice();
+        let offCommands = 0;
+        device.getCapabilityValue = () => undefined;
+        device.samsungClient.turnOff = async () => {
+            offCommands++;
+        };
+        device.isDeviceOnline = async () => false;
+
+        const command = device.turnOnOff(false);
+        await new Promise(resolve => setImmediate(resolve));
+        await device.doOnOffPollDevice();
+        await command;
+
+        expect(offCommands).to.equal(1);
+    });
+
+    it("preserves the separate Frame TV power-off path", async function () {
+        const {device} = createTransitionDevice();
+        let offCommands = 0;
+        device.getCapabilityValue = () => false;
+        device.getSetting = function () {
+            const [key] = arguments;
+            return key === DeviceSettings.frameTVSupport ? true : undefined;
+        };
+        device.samsungClient.turnOff = async () => {
+            offCommands++;
+        };
+        device.isDeviceOnline = async () => false;
+
+        const command = device.turnOnOff(false);
+        await new Promise(resolve => setImmediate(resolve));
+        await device.doOnOffPollDevice();
+        await command;
+
+        expect(offCommands).to.equal(1);
+    });
+
     it("cleans up after a rejected power command", async function () {
         const {device} = createTransitionDevice();
         device.samsungClient.wake = async () => {


### PR DESCRIPTION
## Summary

- Skip the maintained non-Frame driver's off transition when Homey's current `onoff` capability is explicitly `false`.
- Preserve the existing off-command path for known-on and unknown states.
- Preserve the separate Frame TV long-hold path.

Fixes #60

Task source: `tasks/community-posts/power-off-command-turns-off-tv-on.md`

## Evidence and TDD

The maintained client uses toggle-style `KEY_POWER` for non-Frame `turnOff()`. Before this change, `SamsungDevice.turnOnOff(false)` reached that client command even when `onoff` was already explicitly `false`.

Red: the focused known-off regression test failed because `samsungClient.turnOff()` was reached and raised `redundant power-off command was sent`.

Green: all 11 focused `SamsungDevice power transitions` cases pass, including known-off suppression, known-on dispatch, unknown-state dispatch, and preservation of the Frame path.

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 58 passing

No manifest, locale, generated `app.json`, shared-library, encrypted-driver, or legacy-driver changes were required.

## Hardware limitations

Real-TV verification remains outstanding. The idempotent non-Frame behavior should be checked on an ordinary modern Samsung TV. The Frame dispatch path is unchanged and remains unverified without compatible hardware; unit tests do not establish Frame compatibility.
