### PR TITLE
Document Samsung standby power-state limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ Interval between each time the status of the TV (on / off) is checked, in second
 
 A value lower than 10 seconds will disable the polling.
 
+#### Unexpected on/off Flow triggers
+
+The app determines whether the TV is on from the status and network services reported by the TV. Some Samsung TVs
+and projectors temporarily wake their network services while the display remains off, for example during standby
+maintenance or SmartThings activity. Some models may also report that they are on while the screen or projector lamp
+is not active.
+
+Homey can therefore briefly show the TV as on and run a "TV turned on" Flow, followed later by a "TV turned off"
+Flow, even though nobody visibly turned on the display. This behavior depends on the model and firmware. The app
+cannot reliably distinguish an active display from an awake network connection on every Samsung device. Frame TV
+and projector power states may also not fit a simple on/off value.
+
+If unexpected power triggers cause unwanted actions:
+
+- Disable **Power state polling** in the device's Advanced settings. Use the **Set power state** action from a Flow
+  driven by a more reliable source, such as power consumption measured by a smart plug or another integration.
+- Alternatively, add a delay and confirm that the TV still reports as on before operating curtains, lights, or other
+  devices. This may filter short standby wakeups, but it is not a guarantee.
+
+Changing only the polling interval changes how often the state is checked; it does not make the reported state more
+reliable.
+
 #### Maximum volume level
 
 Set the maximum volume level used for UPnP get and set volume. Default value is 30.

--- a/tasks/community-posts/false-power-state-transitions-trigger-flows.md
+++ b/tasks/community-posts/false-power-state-transitions-trigger-flows.md
@@ -1,6 +1,6 @@
 # False power state transitions trigger flows while the TV remains unchanged
 
-Status: Candidate bug
+Status: Limitation documented — [GitHub issue #62](https://github.com/balmli/com.samsung.smart/issues/62)
 
 Area: Maintained `Samsung` driver and shared power-state reconciliation
 
@@ -19,6 +19,16 @@ Users report Homey firing TV-on and TV-off triggers even though the physical dis
 - Capability changes can fire Homey triggers even when a probe is transient or contradictory.
 - The behavior may be related to polling, websocket availability, UPnP availability, or devices briefly exposing network services without actually turning the display on.
 
+## Confirmation evidence
+
+The maintained driver uses Samsung's reported `PowerState` where available and otherwise combines API, UPnP, and
+remote-control port reachability. These signals can prove that the TV's network stack is awake, but they cannot prove
+that the physical panel or projector lamp is active. If Samsung reports `on` during standby, the app has no universal
+authoritative display-state signal with which to reject it.
+
+Debounce, probe voting, and timing heuristics cannot guarantee correct model-independent behavior. The user-facing
+limitation and available mitigations are therefore documented instead of changing runtime behavior.
+
 ## Expected behavior
 
 Homey should fire power-state triggers only after a reliable, stable physical state transition.
@@ -34,3 +44,15 @@ Homey should fire power-state triggers only after a reliable, stable physical st
 ## Hardware verification
 
 Requires observation on a modern TV or Samsung Freestyle device with timeline logging. Do not mark resolved from unit tests alone.
+
+## Documentation and verification
+
+- `README.md` now explains to end users that Samsung standby network activity can cause temporary on/off state and
+  Flow triggers without visibly activating the display.
+- The documented mitigations are to disable power-state polling and drive the **Set power state** action from a more
+  reliable external signal, or to add delayed confirmation while recognizing that it is not guaranteed.
+- No runtime, shared-library, retained-driver, manifest, locale, capability, setting, Flow-card, or generated
+  `app.json` behavior changed.
+- Node 24.16.0 checks passed: `npm run format`, `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (58 passing).
+- No hardware verification is claimed; model, firmware, Frame TV, and projector behavior remains variable.

--- a/tasks/community-posts/false-power-state-transitions-trigger-flows.md
+++ b/tasks/community-posts/false-power-state-transitions-trigger-flows.md
@@ -2,6 +2,8 @@
 
 Status: Limitation documented — [GitHub issue #62](https://github.com/balmli/com.samsung.smart/issues/62)
 
+Pull request: [#63](https://github.com/balmli/com.samsung.smart/pull/63)
+
 Area: Maintained `Samsung` driver and shared power-state reconciliation
 
 ## Problem


### PR DESCRIPTION
## Summary

- Document why Samsung standby network activity can produce temporary TV turned-on and turned-off Flow triggers without visibly activating the display.
- Explain that the behavior varies by model and firmware and cannot be distinguished reliably on every Samsung device.
- Give end users practical mitigations for Flows that operate curtains, lights, or other disruptive devices.

Fixes #62

Task source: `tasks/community-posts/false-power-state-transitions-trigger-flows.md`

## User guidance

The new README section recommends either:

- disabling **Power state polling** and driving **Set power state** from a trusted external signal such as smart-plug power measurement; or
- adding delayed confirmation while clearly stating that this can filter short standby wakeups but is not guaranteed.

It also explains that changing only the polling interval changes frequency, not reliability, and calls out Frame TV and projector state ambiguity.

## Scope

Documentation only. No runtime, shared-library, retained-driver, manifest, locale, capability, setting, Flow-card, or generated `app.json` behavior changed. The pre-existing local `app.json` formatting change is not included in this branch commit.

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 58 passing

No hardware verification is claimed; the documented behavior remains dependent on Samsung model, firmware, standby behavior, Frame mode, and projector semantics.
