### PR TITLE
Improve 401 errors for application launch actions

### DIFF
--- a/drivers/Samsung/SamsungClient.ts
+++ b/drivers/Samsung/SamsungClient.ts
@@ -4,6 +4,10 @@ import {SamsungBase, SamsungClient} from '../../lib/SamsungBase';
 const WebSocket = require('ws');
 
 export class SamsungClientImpl extends SamsungBase implements SamsungClient {
+    protected getApplicationRequestError(statusCode: number): string | undefined {
+        return statusCode === 401 ? this.device?.homey.__('errors.app_request_401') : undefined;
+    }
+
     getUri(ipAddress?: string) {
         return `http://${ipAddress || this.config.getSetting(DeviceSettings.ipaddress)}:${this.port}/api/v2/`;
     }
@@ -132,6 +136,17 @@ export class SamsungClientImpl extends SamsungBase implements SamsungClient {
                 },
             },
         });
+    }
+
+    async launchYouTube(videoId: string): Promise<void> {
+        try {
+            await this.launchApp({name: 'YouTube', appId: '', dialId: 'YouTube'}, 'v=' + videoId);
+            this.logger.verbose(`launchYouTube: started YouTube with video ID: ${videoId}`);
+        } catch (err: any) {
+            this.logger.info(`launchYouTube: error starting Youtube for video ID: ${videoId}`, err);
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(this.device?.homey.__('errors.app.start_youtube', {message}));
+        }
     }
 
     async artMode(onOff: boolean): Promise<any> {

--- a/lib/SamsungBase.ts
+++ b/lib/SamsungBase.ts
@@ -159,6 +159,10 @@ export class SamsungBase implements SamsungClient {
     socket: any;
     socketTimeout?: NodeJS.Timeout;
 
+    protected getApplicationRequestError(statusCode: number): string | undefined {
+        return undefined;
+    }
+
     constructor({
         device,
         config,
@@ -540,6 +544,12 @@ export class SamsungBase implements SamsungClient {
                         self.logger.info(`Application command failed: ${cmd} ${appId}:`, msg);
                         reject(msg);
                     } else {
+                        const msg = self.getApplicationRequestError(data.response.statusCode);
+                        if (msg) {
+                            self.logger.info(`Application command failed: ${cmd} ${appId}:`, msg);
+                            reject(msg);
+                            return;
+                        }
                         self.logger.error(
                             'Application command',
                             data.data,

--- a/locales/en.json
+++ b/locales/en.json
@@ -38,6 +38,7 @@
     "frame_is_not_supported": "Frame is not supported",
     "app_no_app_running": "No app is running...",
     "app_app_not_running": "App is not running...",
+    "app_request_401": "The TV rejected the application request. Make sure the app is installed and supported on this TV",
     "app_request_403": "The application request must be authorized",
     "app_request_404": "Application not found",
     "app_request_413": "Request entity too large",

--- a/tasks/community-posts/application-launch-401-error-message.md
+++ b/tasks/community-posts/application-launch-401-error-message.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #64](https://github.com/balmli/com.samsung.smart/issues/64)
 
+Pull request: [#65](https://github.com/balmli/com.samsung.smart/pull/65)
+
 Area: Maintained `Samsung` driver application launching
 
 ## Problem

--- a/tasks/community-posts/application-launch-401-error-message.md
+++ b/tasks/community-posts/application-launch-401-error-message.md
@@ -1,0 +1,68 @@
+# Application launch returns an unhelpful 401 Unauthorized error
+
+Status: Fix implemented — [GitHub issue #64](https://github.com/balmli/com.samsung.smart/issues/64)
+
+Area: Maintained `Samsung` driver application launching
+
+## Problem
+
+When a user launches an app that is not installed on the TV, some modern Samsung TVs return HTTP 401. The app
+currently exposes this as `Operation failed (401 Unauthorized)`, which does not explain the likely cause or tell the
+user what to check.
+
+The **Launch video on YouTube** action uses the same application endpoint. If YouTube is not installed and the TV
+returns 401, users should receive the same actionable explanation with YouTube context.
+
+## Evidence
+
+- Maintainer hardware reproduction on 2026-07-20: launching an app that was not installed on the TV returned
+  `Operation failed (401 Unauthorized)`.
+- `SamsungBase._applicationCmd()` has explicit mappings for 403, 404, 413, 501, and 503, but 401 falls through to
+  the generic status message.
+- `SamsungBase.launchYouTube()` reads `err.message`, while application-command status failures are rejected as
+  strings. A YouTube launch failure can therefore lose the underlying message.
+
+## Related community tasks
+
+- [`installed-app-discovery-incomplete.md`](installed-app-discovery-incomplete.md) covers authoritative installed-app
+  discovery and launch metadata.
+- [`youtube-launch-unauthorized.md`](youtube-launch-unauthorized.md) covers whether YouTube launching and deep links
+  are supported across current TV models.
+
+This task improves error reporting only. It does not claim to fix app discovery, install an absent app, or make
+YouTube deep-link launching compatible with unsupported models.
+
+## Expected behavior
+
+For the maintained Samsung driver, an HTTP 401 application response should explain that the TV rejected the request
+and advise the user to verify that the app is installed and supported. The **Launch video on YouTube** action should
+preserve that underlying message instead of displaying an undefined or generic error.
+
+## Acceptance criteria
+
+- Add a focused regression test for a 401 response from **Launch app**.
+- Add a focused regression test proving that **Launch video on YouTube** preserves string-based application errors.
+- Keep the wording actionable without claiming that every 401 definitively means the app is absent.
+- Preserve existing mappings for 403, 404, 413, 501, and 503.
+- Keep retained encrypted and legacy driver behavior unchanged.
+
+## Hardware verification
+
+The direct app-launch 401 behavior has been reproduced on maintained Samsung hardware. The YouTube-not-installed
+case remains unverified on hardware; its shared response handling is covered deterministically by tests.
+
+## Implementation and verification
+
+- The maintained `Samsung` client maps HTTP 401 application responses to an actionable message advising users to
+  verify that the app is installed and supported.
+- The maintained YouTube action now preserves both string and `Error` messages from the underlying application
+  request. Installed-app discovery and YouTube protocol compatibility are unchanged.
+- A no-op shared hook leaves retained encrypted-driver response mapping unchanged; the legacy driver does not expose
+  application launch actions.
+- Regression test red: direct app launch returned `Operation failed (401 Unauthorized)`, and the YouTube wrapper
+  rendered the string failure as `undefined`. The shared-base preservation case already passed.
+- Regression test green: all three focused cases passed after the maintained-driver overrides.
+- Node 24.16.0 checks passed: `npm run format`, `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (61 passing).
+- The locale changed only for the new maintained-driver message. No manifest, Flow-card, setting, capability, or
+  generated `app.json` changes were required.

--- a/test/test_application_launch_errors.ts
+++ b/test/test_application_launch_errors.ts
@@ -1,0 +1,106 @@
+const expect = require("chai").expect;
+const http = require("http.min");
+
+import {SamsungBase} from "../lib/SamsungBase";
+import {SamsungClientImpl} from "../drivers/Samsung/SamsungClient";
+
+const messages: Record<string, string> = {
+    "errors.app_request_401":
+        "The TV rejected the application request. Make sure the app is installed and supported on this TV",
+    "errors.app_request_failed": "Operation failed (__statusCode__ __statusMessage__)",
+    "errors.app.start_youtube": "Unable to start YouTube (__message__).",
+};
+
+function translate(key: string, values: Record<string, string | number> = {}) {
+    let message = messages[key];
+    for (const [name, value] of Object.entries(values)) {
+        message = message.replace(`__${name}__`, String(value));
+    }
+    return message;
+}
+
+function createClient(Client: any = SamsungClientImpl) {
+    return new Client({
+        device: {
+            homey: {
+                __: translate,
+            },
+        },
+        config: {
+            getSetting: () => "192.0.2.1",
+        },
+        port: 8001,
+        homeyIpUtil: {},
+        logger: {
+            error: () => undefined,
+            info: () => undefined,
+            verbose: () => undefined,
+        },
+    });
+}
+
+describe("Samsung application launch errors", function () {
+    const originalPost = http.post;
+
+    afterEach(function () {
+        http.post = originalPost;
+    });
+
+    it("explains a 401 response from the maintained driver", async function () {
+        const client = createClient();
+        http.post = async () => ({
+            data: "",
+            response: {
+                statusCode: 401,
+                statusMessage: "Unauthorized",
+            },
+        });
+
+        let errorMessage;
+        try {
+            await client.launchApp({name: "Missing app", appId: "missing-app", dialId: ""});
+        } catch (err) {
+            errorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(errorMessage).to.equal(messages["errors.app_request_401"]);
+    });
+
+    it("preserves a string application error for the YouTube action", async function () {
+        const client = createClient();
+        client.launchApp = async () => {
+            throw messages["errors.app_request_401"];
+        };
+
+        let errorMessage;
+        try {
+            await client.launchYouTube("abcdefghijk");
+        } catch (err) {
+            errorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(errorMessage).to.equal(
+            `Unable to start YouTube (${messages["errors.app_request_401"]}).`,
+        );
+    });
+
+    it("keeps the shared base 401 response unchanged", async function () {
+        const client = createClient(SamsungBase);
+        http.post = async () => ({
+            data: "",
+            response: {
+                statusCode: 401,
+                statusMessage: "Unauthorized",
+            },
+        });
+
+        let errorMessage;
+        try {
+            await client._applicationCmd("http://192.0.2.1/apps/missing", "missing-app", "post", false);
+        } catch (err) {
+            errorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(errorMessage).to.equal("Operation failed (401 Unauthorized)");
+    });
+});


### PR DESCRIPTION
## Summary

- Map HTTP 401 application responses in the maintained Samsung driver to an actionable message: the TV rejected the request, so verify that the app is installed and supported.
- Preserve string-based application errors in the maintained **Launch video on YouTube** wrapper instead of displaying `undefined`.
- Leave retained encrypted-driver response mapping unchanged through a no-op shared hook.

Fixes #64

Task source: `tasks/community-posts/application-launch-401-error-message.md`

## Evidence and TDD

Maintainer hardware reproduction on 2026-07-20 showed that launching an app not installed on the TV returned `Operation failed (401 Unauthorized)`.

Red:

- **Launch app** returned the generic `Operation failed (401 Unauthorized)` message.
- **Launch video on YouTube** converted the string application failure into `Unable to start YouTube (undefined).`
- The shared-base preservation case already passed.

Green: all three focused cases pass after the maintained-driver mapping and wrapper override.

## Scope

This improves error reporting only. It does not fix installed-app discovery, install missing apps, or establish YouTube/deep-link compatibility across TV models.

The new shared hook returns no mapping by default, so retained encrypted-driver behavior is unchanged. The legacy driver does not expose application launch actions. No Flow card, manifest, setting, capability, or generated `app.json` changes are included.

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 61 passing

## Hardware limitations

The direct app-launch 401 response was reproduced on maintained Samsung hardware. The YouTube-not-installed case remains unverified on hardware; deterministic tests cover its shared response path. No retained-driver hardware verification is claimed.
