### PR TITLE
Avoid Homey timeout during slow power transitions

### DIFF
--- a/drivers/Samsung/device.ts
+++ b/drivers/Samsung/device.ts
@@ -7,8 +7,6 @@ module.exports = class SamsungDevice extends BaseDevice {
     pairRetries: number = 3;
     lastAppsRefreshTs: number = 0;
     private onlineRefreshPromise?: Promise<void>;
-    private powerTransitionResolve?: () => void;
-    private powerTransitionReject?: (error: Error) => void;
 
     async onInit(): Promise<void> {
         this.deleted = false;
@@ -69,12 +67,6 @@ module.exports = class SamsungDevice extends BaseDevice {
             return;
         }
 
-        const transition = new Promise<void>((resolve, reject) => {
-            this.powerTransitionResolve = resolve;
-            this.powerTransitionReject = reject;
-        });
-        transition.catch(() => undefined);
-
         try {
             this.turning_onoff_process = onOff;
             this.scheduleOnOffPolling();
@@ -85,7 +77,7 @@ module.exports = class SamsungDevice extends BaseDevice {
             }
             const command = onOff ? this.samsungClient.wake() : this.samsungClient.turnOff();
             this.logger.info('turnOnOff: in progress: ' + (onOff ? 'on' : 'off'));
-            await Promise.race([command.then(() => transition), transition]);
+            await command;
         } catch (err) {
             this.finishPowerTransition();
             this.logger.info('turnOnOff: failed: ', err);
@@ -124,7 +116,8 @@ module.exports = class SamsungDevice extends BaseDevice {
             return;
         }
 
-        this.finishPowerTransition(new Error(this.homey.__('errors.connection_timeout')));
+        this.logger.info('turnOnOff: transition timed out');
+        this.finishPowerTransition();
     }
 
     onDeleted() {
@@ -132,21 +125,11 @@ module.exports = class SamsungDevice extends BaseDevice {
         super.onDeleted();
     }
 
-    private finishPowerTransition(error?: Error) {
-        const resolve = this.powerTransitionResolve;
-        const reject = this.powerTransitionReject;
-        this.powerTransitionResolve = undefined;
-        this.powerTransitionReject = undefined;
+    private finishPowerTransition() {
         this.turning_onoff_process = undefined;
         this.wakeRetries = 0;
         this.clearOnOffPolling();
         this.clearOnOffTimeout();
-
-        if (error) {
-            reject?.(error);
-        } else {
-            resolve?.();
-        }
     }
 
     async onSettings({

--- a/tasks/community-posts/power-transition-capability-timeout.md
+++ b/tasks/community-posts/power-transition-capability-timeout.md
@@ -1,0 +1,57 @@
+# Power transition confirmation exceeds Homey capability timeout
+
+Status: Fix implemented — [GitHub issue #66](https://github.com/balmli/com.samsung.smart/issues/66)
+
+Area: Maintained `Samsung` driver power transition lifecycle
+
+## Problem
+
+After the recent power-transition recovery changes, turning off a real Samsung TV can display Homey's
+`Timeout after 10000ms` message even though the command succeeds and the TV eventually turns off. Some TVs take more
+than 10 seconds to become unreachable after accepting the power command.
+
+## Source
+
+- Maintainer hardware test reported on 2026-07-20 after the power-state fixes were merged to `main`.
+
+## Confirmation evidence
+
+The maintained driver's `turnOnOff()` method waits for polling to confirm the requested physical state before its
+capability-listener promise resolves. The transition timeout is 30 seconds, while the observed Homey request timeout is
+10 seconds. Hardware testing confirms that a successful TV shutdown can cross that UI deadline.
+
+## Expected behavior
+
+Once the TV accepts the power command, Homey should acknowledge the capability request without waiting for the physical
+shutdown to finish. Transition polling must continue in the background and retain bounded cleanup, duplicate-command
+protection, and recovery from command or polling failures.
+
+## Intended regression test
+
+- Prove that a successfully sent power command resolves before physical transition polling completes.
+- Prove that transition state and timers remain active until later polling confirms the requested state.
+- Preserve immediate command-failure cleanup, duplicate-command blocking, transition timeout cleanup, initialization,
+  and deletion behavior.
+
+## Scope and hardware limitations
+
+- Change only the maintained `drivers/Samsung/` implementation and its focused unit tests.
+- Do not change the encrypted or legacy drivers.
+- Verify the behavior with deterministic tests. Final confirmation that the Homey UI no longer reports its 10-second
+  timeout requires another real modern Samsung TV test.
+
+## Implementation and verification
+
+- The maintained driver now resolves the Homey capability request after Samsung accepts the power command instead of
+  waiting for the physical state transition to complete.
+- Polling, the 30-second transition bound, duplicate-command protection, Wake-on-LAN retries, and lifecycle cleanup
+  continue in the background.
+- Immediate command failures still reject the capability request and clear transition state. A later background
+  confirmation timeout is logged and cleaned up without attempting to reject an already completed request.
+- Regression test red: the command-send promise resolved, but `turnOnOff()` remained pending until transition cleanup.
+- Regression test green: all 12 focused transition cases pass, including early acknowledgement with active background
+  timers and later cleanup.
+- Node 24.16.0 checks passed: `npm run format`, `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (62 passing).
+- No manifest or generated `app.json` changes were required. Modern Samsung hardware confirmation of the corrected UI
+  behavior remains outstanding; encrypted and legacy drivers were not changed or hardware-tested.

--- a/tasks/community-posts/power-transition-capability-timeout.md
+++ b/tasks/community-posts/power-transition-capability-timeout.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #66](https://github.com/balmli/com.samsung.smart/issues/66)
 
+Pull request: [#67](https://github.com/balmli/com.samsung.smart/pull/67)
+
 Area: Maintained `Samsung` driver power transition lifecycle
 
 ## Problem

--- a/test/test_set_power_state.ts
+++ b/test/test_set_power_state.ts
@@ -243,6 +243,34 @@ describe("SamsungDevice power transitions", function () {
         expect(offCommands).to.equal(1);
     });
 
+    it("acknowledges a sent off command before transition confirmation", async function () {
+        const {device} = createTransitionDevice();
+        device.getCapabilityValue = () => true;
+        let commandSent: () => void = () => undefined;
+        device.samsungClient.turnOff = () =>
+            new Promise<undefined>(resolve => {
+                commandSent = () => resolve(undefined);
+            });
+        let acknowledged = false;
+        const command = device.turnOnOff(false).then(() => {
+            acknowledged = true;
+        });
+
+        try {
+            await new Promise(resolve => setImmediate(resolve));
+            commandSent();
+            await new Promise(resolve => setImmediate(resolve));
+
+            expect(acknowledged).to.equal(true);
+            expect(device.turning_onoff_process).to.equal(false);
+            expect(device.onOffPollingTimeout).to.not.equal(undefined);
+            expect(device.onOffCheckTimeout).to.not.equal(undefined);
+        } finally {
+            device.onDeleted();
+            await command;
+        }
+    });
+
     it("preserves the off command when the current state is unknown", async function () {
         const {device} = createTransitionDevice();
         let offCommands = 0;
@@ -338,19 +366,12 @@ describe("SamsungDevice power transitions", function () {
         expect(device.onOffCheckTimeout).to.equal(undefined);
     });
 
-    it("returns a timeout error and allows a later command", async function () {
+    it("cleans up after a transition timeout and allows a later command", async function () {
         const {device} = createTransitionDevice();
-        let commandErrorMessage;
-        const command = device.turnOnOff(true).catch(function () {
-            const [err] = arguments;
-            commandErrorMessage = err instanceof Error ? err.message : String(err);
-        });
-        await new Promise(resolve => setImmediate(resolve));
+        await device.turnOnOff(true);
 
         device.onOnOffTimeout();
-        await command;
 
-        expect(commandErrorMessage).to.equal("errors.connection_timeout");
         expect(device.turning_onoff_process).to.equal(undefined);
         expect(device.onOffPollingTimeout).to.equal(undefined);
         expect(device.onOffCheckTimeout).to.equal(undefined);


### PR DESCRIPTION
## Summary

- acknowledge Homey's power capability request once Samsung accepts the command
- continue physical transition polling, retry state, duplicate-command protection, and bounded cleanup in the background
- keep immediate command-send failures visible to Homey

Closes #66

## Task source and evidence

Task: `tasks/community-posts/power-transition-capability-timeout.md`

A maintained modern Samsung TV successfully turned off but took longer than Homey's observed 10-second capability
request deadline to become unreachable. Since `turnOnOff()` waited for physical-state polling, Homey displayed
`Timeout after 10000ms` even though shutdown later completed.

## TDD evidence

- Red: the Samsung command-send promise resolved, but the maintained driver's `turnOnOff()` promise remained pending
  until transition cleanup; the focused test failed with `expected false to equal true`.
- Green: all 12 maintained-driver transition tests pass, including acknowledgement while the transition flag and both
  background timers remain active.

## Verification

- `npm run format` — passed
- `npm run build` — passed
- `npm run lint` — passed
- `npm run test:typecheck` — passed
- `npm test --ignore-scripts` — passed, 62 tests

## Scope and limitations

- Only `drivers/Samsung/`, its focused tests, and the linked task record changed.
- No manifest or generated `app.json` changes were required.
- Encrypted and legacy driver behavior was not changed or hardware-tested.
- The original slow-shutdown behavior was observed on real modern Samsung hardware. Confirmation that this change
  removes the Homey UI timeout still requires a follow-up hardware run.
