### PR TITLE
Release 2.2.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,7 @@
 {
+  "2.2.0": {
+    "en": "Improved power-state polling and transition recovery for newer Samsung TVs. Turning off an already-off TV no longer sends a toggle command, slow successful power changes no longer trigger Homey's 10-second timeout, and application-launch authorization errors are clearer."
+  },
   "2.1.0": {
     "en": "Added action to close running app. Improvements to SmartThings API. "
   },

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.samsung.smart",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "compatibility": ">=8.1.2",
   "sdk": 3,
   "brandColor": "#206ADF",

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ Some TVs use a different type of pairing, and are therefore not supported at the
 
 ## Release Notes:
 
+#### 2.2.0
+
+- Improved power-state polling reliability for newer Samsung TVs
+- Power transitions now recover cleanly from command failures, polling failures, and timeouts
+- Turning off a TV that is already known to be off no longer sends a toggle power command
+- Slow successful power changes no longer show Homey's 10-second timeout message
+- Application-launch actions now explain authorization failures more clearly
+- Added guidance for model-dependent standby wakeups and unexpected power-state Flow triggers
+
 #### 2.1.0
 
 - Added action to close running app

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.samsung.smart",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "compatibility": ">=8.1.2",
   "sdk": 3,
   "brandColor": "#206ADF",


### PR DESCRIPTION
## Release 2.2.0

- update the Homey app version from 2.1.0 to 2.2.0 in `.homeycompose/app.json`
- add the newest-first 2.2.0 Homey changelog entry
- add matching newest-first README release notes
- regenerate and format `app.json`

## User-facing changes

- improve power-state polling reliability for newer Samsung TVs
- recover power transitions cleanly from command, polling, and timeout failures
- avoid sending a toggle power command when a non-Frame TV is already known to be off
- acknowledge accepted power commands while slow physical transitions continue in the background
- explain application-launch authorization failures more clearly
- document model-dependent standby wakeups and unexpected power-state Flow triggers

## Verification

- `npm run format` — passed
- `npm run build` — passed
- `npm run test:typecheck` — passed
- `npm test` — passed, 62 tests; normal lifecycle publish validation passed
- `npm run lint` — passed
- `homey app validate --level publish` — passed

## Release review

- generated `app.json` differs semantically only by the version and was formatted after generation
- `.homeycompose/app.json` and generated `app.json` both report 2.2.0
- npm package version remains unchanged at 1.0.0
- no changes under `cmd/`, `drivers/SamsungEncrypted/`, or `drivers/SamsungLegacy/`
- modern Samsung hardware behavior beyond the previously reported slow-shutdown reproduction remains unverified for
  this release; encrypted and legacy TV families were not hardware-tested
- this PR does not create a tag, GitHub release, Homey publication, or merge
