### PR TITLE
Remove Sentry logging

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -10,14 +10,10 @@ class SamsungSmartApp extends Homey.App {
     async onInit() {
         try {
             // @ts-ignore
-            this.logger = new Logger(
-                {
-                    homey: this.homey,
-                    logFunc: this.log,
-                    errorFunc: this.error,
-                },
-                Homey.env,
-            );
+            this.logger = new Logger({
+                logFunc: this.log,
+                errorFunc: this.error,
+            });
 
             await this.initFlows();
 

--- a/lib/BaseDevice.ts
+++ b/lib/BaseDevice.ts
@@ -28,15 +28,10 @@ export class BaseDevice extends Homey.Device {
 
     async initDevice(deviceType: string) {
         // @ts-ignore
-        this.logger = new Logger(
-            {
-                homey: this.homey,
-                logFunc: this.log,
-                errorFunc: this.error,
-            },
-            Homey.env,
-        );
-        await this.initLogger(deviceType);
+        this.logger = new Logger({
+            logFunc: this.log,
+            errorFunc: this.error,
+        });
 
         // @ts-ignore
         this.config = new SamsungConfigImpl({device: this, logger: this.logger});
@@ -47,14 +42,6 @@ export class BaseDevice extends Homey.Device {
 
         await this.updateMacAddress(this.config.getSetting(DeviceSettings.ipaddress));
         await this.setMacAddressHomey();
-    }
-
-    async initLogger(deviceType: string) {
-        this.logger.setTags({deviceType});
-        const modelName = this.getSetting(DeviceSettings.modelName);
-        if (modelName) {
-            this.logger.setTags({modelName});
-        }
     }
 
     async setMacAddressHomey(): Promise<any> {
@@ -492,7 +479,6 @@ export class BaseDevice extends Homey.Device {
                 await this.config
                     .setSetting(DeviceSettings.modelName, modelName)
                     .catch((err: any) => this.logger.error(err));
-                this.logger.setTags({modelName});
                 this.logger.info(`Device settings updated. name: ${name}, modelName: ${modelName}`);
             }
         }

--- a/lib/BaseDriver.ts
+++ b/lib/BaseDriver.ts
@@ -13,14 +13,10 @@ export class BaseDriver extends Homey.Driver {
 
     async initDriver(driverType: string) {
         // @ts-ignore
-        this.logger = new Logger(
-            {
-                homey: this.homey,
-                logFunc: this.log,
-                errorFunc: this.error,
-            },
-            Homey.env,
-        );
+        this.logger = new Logger({
+            logFunc: this.log,
+            errorFunc: this.error,
+        });
 
         this.config = new SamsungConfigImpl({logger: this.logger});
         this.homeyIpUtil = new HomeyIpUtilImpl();

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,7 +1,5 @@
 // @ts-nocheck
 
-import Homey from 'homey/lib/Homey';
-
 const logLevelMap = new Map([
     ['silly', 1],
     ['debug', 2],
@@ -10,57 +8,31 @@ const logLevelMap = new Map([
     ['warn', 5],
     ['error', 6],
 ]);
-const sentryLevelMap = new Map([
-    [1, 'debug'],
-    [2, 'debug'],
-    [3, 'debug'],
-    [4, 'info'],
-    [5, 'warning'],
-    [6, 'error'],
-]);
 const logLevelNameMap = new Map(
     Array.from(logLevelMap.entries()).map(entry => [entry[1], entry[0][0].toUpperCase().concat(entry[0].slice(1))]),
 );
 
 /**
  * @class Logger
- * This class is used by all RFDriver classes to dynamically print logs and send logs to sentry
+ * This class is used by all RFDriver classes to dynamically print logs.
  */
 export class Logger {
-    constructor(
-        {
-            homey,
-            logLevel = 3,
-            captureLevel = 5,
-            prefix,
-            logFunc,
-            errorFunc,
-        }: {
-            homey?: Homey;
-            logLevel?: number | string;
-            captureLevel?: number | string;
-            prefix?: string;
-            logFunc?: Function;
-            errorFunc?: Function;
-        },
-        homeyEnv,
-    ) {
-        // Load homey-log and create pre-bound functions or function stubs for logger
-        const log = homey && typeof homeyEnv.HOMEY_LOG_URL === 'string' ? require('homey-log') : undefined;
-        const homeyLog = log ? new log.Log({homey}) : undefined;
-
+    constructor({
+        logLevel = 3,
+        prefix,
+        logFunc,
+        errorFunc,
+    }: {
+        logLevel?: number | string;
+        prefix?: string;
+        logFunc?: Function;
+        errorFunc?: Function;
+    }) {
         this.setLogLevel(logLevel);
-        this.setCaptureLevel(captureLevel);
 
         this.logFunc = logFunc || console.log;
         this.errorFunc = errorFunc || console.error;
         this.prefix = prefix ? `[${[].concat(prefix).join('][')}]` : '';
-
-        this.setTags = homeyLog ? homeyLog.setTags.bind(homeyLog) : () => null;
-        this.setUser = homeyLog ? homeyLog.setUser.bind(homeyLog) : () => null;
-        this.setExtra = homeyLog ? homeyLog.setExtra.bind(homeyLog) : () => null;
-        this.captureMessage = homeyLog ? homeyLog.captureMessage.bind(homeyLog) : () => null;
-        this.captureException = homeyLog ? homeyLog.captureException.bind(homeyLog) : () => null;
 
         // Bind logging functions with this to ensure right this context
         this.log = this._log.bind(this);
@@ -94,40 +66,11 @@ export class Logger {
     }
 
     /**
-     * Can be used to dynamically set the captureLevel of the logger
-     * @param {String} captureLevel The level at which logs are send to sentry. can be 'silly'|'debug'|'verbose'|'info'|'warn'|'error'.
-     * @returns {number} result The id of the captureLevel
-     */
-    setCaptureLevel(captureLevel) {
-        if (!isNaN(captureLevel) && logLevelNameMap.has(captureLevel)) {
-            this.captureLevel = Number(captureLevel);
-        } else if (logLevelMap.has(captureLevel)) {
-            this.captureLevel = logLevelMap.get(captureLevel);
-        } else {
-            throw new Error(
-                `Unsupported captureLevel (${captureLevel}) given. Please choose from ${logLevelMap
-                    .entries()
-                    .map(entry => entry.join(':'))
-                    .join(', ')}`,
-            );
-        }
-        return this.captureLevel;
-    }
-
-    /**
      * Get the label of the current log level
      * @returns {String} logLevelLabel The label of the logLevel. can be 'silly'|'debug'|'verbose'|'info'|'warn'|'error'.
      */
     getLogLevelLabel() {
         return logLevelNameMap.get(this.logLevel);
-    }
-
-    /**
-     * Get the label of the current capture level
-     * @returns {String} captureLevelLabel The label of the captureLevel. can be 'silly'|'debug'|'verbose'|'info'|'warn'|'error'.
-     */
-    getCaptureLevelLabel() {
-        return logLevelNameMap.get(this.captureLevel);
     }
 
     /**
@@ -156,19 +99,6 @@ export class Logger {
                 this.logFunc.apply(null, [`${this.prefix}[${logLevelNameMap.get(logLevelId)}]`].concat(logArgs));
             }
         }
-        if (this.captureLevel <= logLevelId) {
-            if (logLevelId === 6 && logArgs[0] instanceof Error) {
-                this.captureException(
-                    logArgs[0],
-                    Object.assign(
-                        {level: sentryLevelMap.get(logLevelId)},
-                        typeof logArgs[1] === 'object' ? logArgs[1] : null,
-                    ),
-                );
-            } else {
-                this.captureMessage(Array.prototype.join.call(logArgs, ' '), {level: sentryLevelMap.get(logLevelId)});
-            }
-        }
     }
 
     /**
@@ -178,7 +108,7 @@ export class Logger {
      * @memberof Logger
      */
     _silly() {
-        if (this.captureLevel <= 1 || this.logLevel <= 1) {
+        if (this.logLevel <= 1) {
             this.log.bind(null, 'silly').apply(null, arguments);
         }
     }
@@ -190,7 +120,7 @@ export class Logger {
      * @memberof Logger
      */
     _debug() {
-        if (this.captureLevel <= 2 || this.logLevel <= 2) {
+        if (this.logLevel <= 2) {
             this.log.bind(null, 'debug').apply(null, arguments);
         }
     }
@@ -202,7 +132,7 @@ export class Logger {
      * @memberof Logger
      */
     _verbose() {
-        if (this.captureLevel <= 3 || this.logLevel <= 3) {
+        if (this.logLevel <= 3) {
             this.log.bind(null, 'verbose').apply(null, arguments);
         }
     }
@@ -214,7 +144,7 @@ export class Logger {
      * @memberof Logger
      */
     _info() {
-        if (this.captureLevel <= 4 || this.logLevel <= 4) {
+        if (this.logLevel <= 4) {
             this.log.bind(null, 'info').apply(null, arguments);
         }
     }
@@ -226,7 +156,7 @@ export class Logger {
      * @memberof Logger
      */
     _warn() {
-        if (this.captureLevel <= 5 || this.logLevel <= 5) {
+        if (this.logLevel <= 5) {
             this.log.bind(null, 'warn').apply(null, arguments);
         }
     }
@@ -238,7 +168,7 @@ export class Logger {
      * @memberof Logger
      */
     _error() {
-        if (this.captureLevel <= 6 || this.logLevel <= 6) {
+        if (this.logLevel <= 6) {
             this.log.bind(null, 'error').apply(null, arguments);
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@balmli/homey-samsung-encryption": "^1.0.0",
-        "homey-log": "2.1.0",
         "http.min": "2.1.0",
         "is-port-reachable": "3.0.0",
         "macaddress": "0.5.1",
@@ -799,15 +798,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -951,15 +941,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -980,15 +961,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1478,18 +1450,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/homey-log": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/homey-log/-/homey-log-2.1.0.tgz",
-      "integrity": "sha512-BL4AduSZ1Hlzs3vLmExOzNONp3N5GUpG5Ro/R/6+PpKgG4ME5EIcanCuDUWcdXD8y3hJj2KKYqrr0JaggGG/8g==",
-      "license": "ISC",
-      "dependencies": {
-        "raven": "github:athombv/raven-node"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/http.min": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http.min/-/http.min-2.1.0.tgz",
@@ -1518,12 +1478,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1786,17 +1740,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -2201,24 +2144,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/raven": {
-      "version": "2.6.2",
-      "resolved": "git+ssh://git@github.com/athombv/raven-node.git#b8b2b6e007924a79ba4434240f6dfcf431d7c9a1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "5.0.0",
-        "uuid": "3.0.0"
-      },
-      "bin": {
-        "raven": "bin/raven"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2323,15 +2248,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2431,15 +2347,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/timed-out": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-5.0.0.tgz",
-      "integrity": "sha512-+IAmaDqYnVi/HOMCeH4NDzdjTH9EHTC8xbe+PgXMKtovdMjbu25qYxeUj6u/yukMp1wDOhPeh6oTcIVepm5n7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2605,16 +2512,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-      "integrity": "sha512-rqE1LoOVLv3QrZMjb4NkF5UWlkurCfPyItVnFPNKDDGkHw4dQUdE4zMcLqx28+0Kcf3+bnUk4PisaiRJT4aiaQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/balmli/com.samsung.smart#readme",
   "dependencies": {
     "@balmli/homey-samsung-encryption": "^1.0.0",
-    "homey-log": "2.1.0",
     "http.min": "2.1.0",
     "is-port-reachable": "3.0.0",
     "macaddress": "0.5.1",

--- a/tasks/remove-sentry-logging.md
+++ b/tasks/remove-sentry-logging.md
@@ -2,6 +2,8 @@
 
 Status: Fix implemented — [GitHub issue #69](https://github.com/balmli/com.samsung.smart/issues/69)
 
+Pull request: [#70](https://github.com/balmli/com.samsung.smart/pull/70)
+
 Area: Shared application logging
 
 ## Problem

--- a/tasks/remove-sentry-logging.md
+++ b/tasks/remove-sentry-logging.md
@@ -1,0 +1,62 @@
+# Remove Sentry logging
+
+Status: Fix implemented — [GitHub issue #69](https://github.com/balmli/com.samsung.smart/issues/69)
+
+Area: Shared application logging
+
+## Problem
+
+The app sends warnings and errors to Sentry through `homey-log`. When a request to Sentry times out, the rejected
+capture promise is not handled and Homey reports an `unhandledRejection` that may crash the app in the future.
+
+Reported failure:
+
+```text
+Error: Connection timed out on request to o230410.ingest.sentry.io
+  at Timeout.<anonymous> (/node_modules/timed-out/index.js:14:18)
+  at listOnTimeout (node:internal/timers:588:17)
+  at process.processTimers (node:internal/timers:523:7)
+```
+
+## Evidence
+
+- `Logger` conditionally constructs `homey-log` whenever Homey provides `HOMEY_LOG_URL`.
+- `homey-log@2.1.0` installs Raven with unhandled-rejection capture enabled.
+- Its `captureMessage()` and `captureException()` methods return promises that reject when Sentry delivery fails.
+- `Logger._log()` invokes those methods without awaiting or catching the returned promises.
+- The reported stack names the Sentry ingestion host and the timeout dependency used by the reporting path, so the
+  failure does not depend on Samsung TV hardware behavior.
+
+## Expected behavior
+
+The app should continue writing through its normal Homey logger without initializing Sentry or making remote crash
+reporting requests. A Sentry outage must not be able to create an unhandled rejection in the app.
+
+## Acceptance criteria
+
+- Add a focused regression test proving the logger has no remote capture API or capture-level behavior.
+- Remove `homey-log` and its transitive Sentry/Raven dependencies from the application package.
+- Preserve local log-level filtering and Homey-provided log/error functions.
+- Remove obsolete Sentry tag and capture configuration from the shared logger and its callers.
+- Do not change Samsung TV protocol behavior in any driver.
+
+## Compatibility and hardware verification
+
+The change affects the shared logger used by all three protocol drivers, but only removes remote telemetry. No TV
+wire format, pairing, command, polling, or capability behavior is changed. Automated checks can verify the logging
+contract and package contents; TV-family hardware compatibility remains unverified and is not claimed.
+
+## Implementation and verification
+
+- Removed Sentry capture levels, capture methods, context tags, `HOMEY_LOG_URL` handling, and `homey-log`
+  initialization from the shared logger and its callers.
+- Removed `homey-log` and its transitive Raven, timeout, and support packages from the application dependency lock.
+- Preserved local log-level filtering and the Homey-provided log and error functions.
+- Regression test red: the logger still exposed `captureLevel`, causing the focused assertion to fail.
+- Regression test green: the logger exposes no remote capture state or methods, while warning and `Error` output is
+  still routed to the supplied local functions.
+- Node 24.16.0 checks passed: `npm run format`, `npm run build`, `npm run lint`, `npm run test:typecheck`, and
+  `npm test --ignore-scripts` (63 passing).
+- `homey app validate --level publish` passed. The generated `app.json` was inspected and has no committed diff.
+- No TV hardware testing was needed for this telemetry-only change. Protocol compatibility for all TV families
+  remains unverified and is not claimed.

--- a/test/test_create_samsung_client.ts
+++ b/test/test_create_samsung_client.ts
@@ -7,7 +7,7 @@ import {SamsungClientImpl} from "../drivers/Samsung/SamsungClient";
 const logger = new Logger({
     logFunc: console.log,
     errorFunc: console.error,
-}, {});
+});
 const device = new HomeyDeviceMock({logger});
 const config = new SamsungConfigImpl({logger});
 const homeyIpUtil = new HomeyIpUtilImpl();
@@ -21,4 +21,3 @@ export const createSamsungClient = () => new SamsungClientImpl({
     homeyIpUtil,
     logger,
 });
-

--- a/test/test_create_samsung_encrypted_client.ts
+++ b/test/test_create_samsung_encrypted_client.ts
@@ -9,7 +9,7 @@ import {DeviceSettings} from "../lib/types";
 const logger = new Logger({
     logFunc: console.log,
     errorFunc: console.error,
-}, {});
+});
 const device = new HomeyDeviceMock({logger});
 const config = new SamsungConfigImpl({logger});
 const homeyIpUtil = new HomeyIpUtilImpl();

--- a/test/test_logger.ts
+++ b/test/test_logger.ts
@@ -1,0 +1,25 @@
+const expect = require("chai").expect;
+
+import {Logger} from "../lib/Logger";
+
+describe("Logger", function () {
+    it("keeps logging local without exposing remote capture behavior", function () {
+        const logs: any[][] = [];
+        const errors: any[][] = [];
+        const logger = new Logger({
+            logLevel: "silly",
+            logFunc: (...args: any[]) => logs.push(args),
+            errorFunc: (...args: any[]) => errors.push(args),
+        });
+
+        (logger as any).warn("warning");
+        (logger as any).error(new Error("failure"));
+
+        expect(logger).not.to.have.property("captureLevel");
+        expect(logger).not.to.have.property("captureMessage");
+        expect(logger).not.to.have.property("captureException");
+        expect(logs).to.deep.equal([["[Warn]", "warning"]]);
+        expect(errors[0][0]).to.equal("[Error]");
+        expect(errors[0][1]).to.equal("failure");
+    });
+});


### PR DESCRIPTION
Fixes #69

## Summary

- remove Sentry/Raven capture behavior from the shared logger
- remove obsolete capture levels and Sentry context tags from logger callers
- remove `homey-log` and its transitive dependency tree
- preserve local log-level filtering and Homey-provided log/error output

Task source: [`tasks/remove-sentry-logging.md`](https://github.com/balmli/com.samsung.smart/blob/fix/remove-sentry-logging/tasks/remove-sentry-logging.md)

## Failure evidence

`homey-log@2.1.0` installs Raven with unhandled-rejection capture enabled. Its capture methods return promises that
reject when delivery fails, while `Logger._log()` invoked them without awaiting or catching them. The reported
`timed-out` stack and Sentry ingestion hostname therefore identify a deterministic remote telemetry failure rather
than TV hardware behavior.

## Regression test

- Red: the focused logger test failed because `Logger` still exposed `captureLevel`.
- Green: the logger now exposes no capture level or remote capture methods, while warnings and `Error` instances are
  still routed to the supplied local logging functions.

## Verification

Run with Node 24.16.0:

- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run test:typecheck`
- `npm test --ignore-scripts` — 63 passing
- `homey app validate --level publish`
- `npm ls homey-log raven timed-out --all` — empty

Publish validation regenerated `app.json`; it was formatted and inspected, and the PR contains no generated
manifest diff.

## Scope and hardware limitations

The shared logger is used by the maintained, encrypted, and legacy drivers, so remote telemetry is removed for all
three. No TV wire format, pairing, command, polling, setting, capability, or Flow behavior changes. This
telemetry-only change was not tested on TV hardware, and no protocol-family hardware compatibility is claimed.
